### PR TITLE
Remove check allowing for debugger connected bypass

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -139,11 +139,11 @@ typedef void (*pFunction)(void);
 		uint32_t calcChecksum = Report_CRC_Result_Value();
 		uint32_t storedChecksum = *expectedCrcMemPtr;
 
-		if(storedChecksum == 0xFFFFFFFF) {
-			//flash is erased but App is valid due to debugger connected
-			//so OK to run anyway
-			storedChecksum = calcChecksum;
-		}
+//		if(storedChecksum == 0xFFFFFFFF) {
+//			//flash is erased but App is valid due to debugger connected
+//			//so OK to run anyway
+//			storedChecksum = calcChecksum;
+//		}
 		if(storedChecksum == calcChecksum) {
 			//flash CRC is correct, so OK to run it
 			pFunction Jump_To_Application;


### PR DESCRIPTION
Comment out the debugger bypass code. This should not be an option in production. However, this change will prevent the use of the debugger. Hence, opting to not merge these changes into develop but to master. 

Tests:

1. Use the release build of the bootloader to load the release build of the application. Ensure this succeeds. 
2. Use the release build of the bootloader. Use the debugger to flash the application onto the unit. Ensure the unit will not boot into application mode. 